### PR TITLE
Add support for proxy connection

### DIFF
--- a/APLSource/Core-1/Connect-1.aplf
+++ b/APLSource/Core-1/Connect-1.aplf
@@ -6,8 +6,10 @@
      (folder rootname)←(0≡⍵)⊃(2↑(⊆⍵),⊂'DEFAULT')('' 'DEFAULT')
      ⍺.State=1:0
 ⍝ Kai:     _←InitConga ''    ⍝ RumbaLean requires `InitConga` to be called early once
-     p←⍺ ClientParameters 0
-     rc cn←2↑DRC.Clt p
+     rc cn←⍺{
+         0∊⍴⍺.ProxyHost:⍺ ConnectDirect 0
+         ⍺ ConnectProxy 0
+     }0
      rc≠0:⎕SIGNAL CongaError rc
      ⍺.Name←cn
      ⍺.LogFileTie←OpenLogFile ⍺

--- a/APLSource/Core-1/ConnectDirect-81.aplf
+++ b/APLSource/Core-1/ConnectDirect-81.aplf
@@ -1,0 +1,5 @@
+ ConnectDirect←{
+     ⍝ ⍺ ←→ Client
+     p←⍺ ClientParameters 0
+     2↑DRC.Clt p
+ }

--- a/APLSource/Core-1/ConnectProxy-81.aplf
+++ b/APLSource/Core-1/ConnectProxy-81.aplf
@@ -1,0 +1,17 @@
+ ConnectProxy←{
+     ⍝ ⍺ ←→ Client
+     pp←⍺ ProxyParameters 0
+     rc cn←2↑DRC.Clt pp
+     req←'CONNECT ',⍺.Host,':',(⍕⍺.Port),' '⍺.Version,CrLf,CrLf
+     rc←DRC.Send cn req
+     rc←↑DRC.Wait cn ⍺.CongaTimeout
+     ⍺.Secure≤⍺.ProxySecure:rc cn
+     rc≠0:⎕SIGNAL CongaError rc
+     ⍺.X509←⎕NEW DRC.X509Cert
+     p←⍺.X509.AsArg
+     p,←⊂'SSLValidation'⍺.TLSFlag
+     p,←⊂'Priority'⍺.TLSPriority
+     p,←⊂'Address'⍺.Host
+     rc←DRC.SetProp cn'StartTLS'p
+     rc cn
+ }

--- a/APLSource/Core-1/NewClient-9.aplf
+++ b/APLSource/Core-1/NewClient-9.aplf
@@ -7,6 +7,9 @@
      c.Host←''
      c.Port←443
      c.Secure←1
+     c.ProxyHost←''
+     c.ProxyPort←443
+     c.ProxySecure←1
      c.CongaTimeout←5000   ⍝ Milli-seconds
      c.ClientTimeout←30    ⍝ Seconds
      c.Name←''

--- a/APLSource/Core-1/ProxyParameters-21.aplf
+++ b/APLSource/Core-1/ProxyParameters-21.aplf
@@ -1,0 +1,12 @@
+ ProxyParameters←{
+     p←⊂'Name' ''
+     p,←⊂'Address'⍺.ProxyHost
+     p,←⊂'Port'⍺.ProxyPort
+     p,←⊂'Mode' 'Text'
+     ~⍺.ProxySecure:p
+     ⍺.X509←⎕NEW DRC.X509Cert
+     p,←⊂'X509'⍺.X509
+     p,←⊂'SSLValidation'⍺.TLSFlag
+     p,←⊂'Priority'⍺.TLSPriority
+     p
+ }


### PR DESCRIPTION
Added support for proxy connection.

Missing tests, has only been manually tested with proxy server in corporate setting where proxy server is non-secure but target host is secure.